### PR TITLE
Add new paramters to Ads and Campaign services

### DIFF
--- a/src/Service/Ads.php
+++ b/src/Service/Ads.php
@@ -187,8 +187,7 @@ final class Ads extends Service
         $CpmBannerAdBuilderAdFieldNames = null,
         $CpmVideoAdBuilderAdFieldNames = null,
         $Page = null
-    )
-    {
+    ) {
         $params = [
             'SelectionCriteria' => $SelectionCriteria,
             'FieldNames' => $FieldNames

--- a/src/Service/Ads.php
+++ b/src/Service/Ads.php
@@ -162,6 +162,11 @@ final class Ads extends Service
      * @param $DynamicTextAdFieldNames
      * @param $TextImageAdFieldNames
      * @param $MobileAppImageAdFieldNames
+     * @param $TextAdBuilderAdFieldNames
+     * @param $MobileAppAdBuilderAdFieldNames
+     * @param $CpcVideoAdBuilderAdFieldNames
+     * @param $CpmBannerAdBuilderAdFieldNames
+     * @param $CpmVideoAdBuilderAdFieldNames
      * @param $Page
      * @return array
      * @throws Exception
@@ -176,8 +181,14 @@ final class Ads extends Service
         $DynamicTextAdFieldNames = null,
         $TextImageAdFieldNames = null,
         $MobileAppImageAdFieldNames = null,
+        $TextAdBuilderAdFieldNames = null,
+        $MobileAppAdBuilderAdFieldNames = null,
+        $CpcVideoAdBuilderAdFieldNames = null,
+        $CpmBannerAdBuilderAdFieldNames = null,
+        $CpmVideoAdBuilderAdFieldNames = null,
         $Page = null
-    ) {
+    )
+    {
         $params = [
             'SelectionCriteria' => $SelectionCriteria,
             'FieldNames' => $FieldNames
@@ -201,6 +212,26 @@ final class Ads extends Service
 
         if ($MobileAppImageAdFieldNames) {
             $params['MobileAppImageAdFieldNames'] = $MobileAppImageAdFieldNames;
+        }
+
+        if ($TextAdBuilderAdFieldNames) {
+            $params['TextAdBuilderAdFieldNames'] = $TextAdBuilderAdFieldNames;
+        }
+
+        if ($MobileAppAdBuilderAdFieldNames) {
+            $params['MobileAppAdBuilderAdFieldNames'] = $MobileAppAdBuilderAdFieldNames;
+        }
+
+        if ($CpcVideoAdBuilderAdFieldNames) {
+            $params['CpcVideoAdBuilderAdFieldNames'] = $CpcVideoAdBuilderAdFieldNames;
+        }
+
+        if ($CpmBannerAdBuilderAdFieldNames) {
+            $params['CpmBannerAdBuilderAdFieldNames'] = $CpmBannerAdBuilderAdFieldNames;
+        }
+
+        if ($CpmVideoAdBuilderAdFieldNames) {
+            $params['CpmVideoAdBuilderAdFieldNames'] = $CpmVideoAdBuilderAdFieldNames;
         }
 
         if ($Page) {

--- a/src/Service/Campaigns.php
+++ b/src/Service/Campaigns.php
@@ -76,6 +76,7 @@ final class Campaigns extends Service
      * @param array $TextCampaignFieldNames
      * @param array $MobileAppCampaignFieldNames
      * @param array $DynamicTextCampaignFieldNames
+     * @param array $CpmBannerCampaignFieldNames
      * @param array $Page
      * @return array
      * @throws Exception
@@ -88,6 +89,7 @@ final class Campaigns extends Service
         $TextCampaignFieldNames = null,
         $MobileAppCampaignFieldNames = null,
         $DynamicTextCampaignFieldNames = null,
+        $CpmBannerCampaignFieldNames = null,
         $Page = null
     ) {
         $params = [
@@ -105,6 +107,10 @@ final class Campaigns extends Service
 
         if ($DynamicTextCampaignFieldNames) {
             $params['DynamicTextCampaignFieldNames'] = $DynamicTextCampaignFieldNames;
+        }
+
+        if ($CpmBannerCampaignFieldNames) {
+            $params['CpmBannerCampaignFieldNames'] = $CpmBannerCampaignFieldNames;
         }
 
         if ($Page) {


### PR DESCRIPTION
1. Campaign service, method get add parameter $CpmBannerCampaignFieldNames.
2. Ads service, method get add parameters: $TextAdBuilderAdFieldNames, $MobileAppAdBuilderAdFieldNames, $CpcVideoAdBuilderAdFieldNames, $CpmBannerAdBuilderAdFieldNames, $CpmVideoAdBuilderAdFieldNames 