### PR TITLE
checkDictionaries can be called with no params

### DIFF
--- a/src/Service/Changes.php
+++ b/src/Service/Changes.php
@@ -26,13 +26,18 @@ final class Changes extends Service
      *
      * @see https://tech.yandex.ru/direct/doc/ref-v5/changes/checkDictionaries-docpage/
      */
-    public function checkDictionaries($Timestamp)
+    public function checkDictionaries($Timestamp = null)
     {
-        return $this->request([
-            'method' => 'checkDictionaries',
-            'params' => [
+        $params = [];
+        if (!is_null($Timestamp)) {
+            $params = [
                 'Timestamp' => $Timestamp
             ]
+        }
+        
+        return $this->request([
+            'method' => 'checkDictionaries',
+            'params' => $params
         ]);
     }
 


### PR DESCRIPTION
`Changes->checkDictionaries` can be called without `Timestamp` parameter:

> Если метод вызван без параметра Timestamp, возвращается только текущее время на сервере.

https://yandex.ru/dev/direct/doc/ref-v5/changes/checkDictionaries-docpage/