### PR TITLE
Empty checkDictionaries query fixed

### DIFF
--- a/src/Service/Changes.php
+++ b/src/Service/Changes.php
@@ -30,8 +30,12 @@ final class Changes extends Service
      */
     public function checkDictionaries($Timestamp = null)
     {
-        $params = compact(get_param_names(__METHOD__));
-
+        if (!is_null($Timestamp)) {
+            $params = ['Timestamp' => $Timestamp];
+        } else {
+            $params = new \stdClass();
+        }
+        
         return $this->request([
             'method' => 'checkDictionaries',
             'params' => $params


### PR DESCRIPTION
Error while querying checkDictionaries without timestamp has been fixed. Thanks for your recent update in 3.1.2 but it doesn't work - error "Params cannot be null" error is coming back from Yandex Direct API.

`stdClass` is required cuz you have to `json_encode` not empty params (`[]`) but the empty object (`{}`) due to YD API.

I also advise not to stick to the list of parameters - it is gonna be easier to change them in the future.